### PR TITLE
Add Streamlit front end

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,0 +1,11 @@
+import streamlit as st
+from model import train_model, predict_upcoming
+
+st.title("F1 Race Predictor")
+
+if "model" not in st.session_state:
+    st.session_state["model"] = train_model()
+
+if st.button("Run Prediction"):
+    results = predict_upcoming(st.session_state["model"])
+    st.dataframe(results)

--- a/model.py
+++ b/model.py
@@ -1,32 +1,34 @@
-# model.py
 import pandas as pd
-import numpy as np
 from sklearn.ensemble import RandomForestRegressor
 
-# 1) Load the tyre‐enhanced, gap‐&‐delta feature tables
-train = pd.read_csv('features_train_with_tyres.csv')
-up    = pd.read_csv('features_upcoming_with_tyres.csv')
 
-# 2) Split into X / y / weights
-#    Drop the non-feature columns
-drop_cols = ['Year', 'Driver', 'Team', 'Best_Q']
-X_train   = train.drop(columns=drop_cols)
-y_train   = train['Best_Q']
-weights   = train['RecencyWeight']
+def train_model():
+    """Train a RandomForestRegressor on the tyre-enhanced feature table."""
+    train = pd.read_csv('features_train_with_tyres.csv')
+    drop_cols = ['Year', 'Driver', 'Team', 'Best_Q']
+    X_train = train.drop(columns=drop_cols)
+    y_train = train['Best_Q']
+    weights = train['RecencyWeight']
 
-# 3) Fit
-model = RandomForestRegressor(n_estimators=200, random_state=42)
-model.fit(X_train, y_train, sample_weight=weights)
+    model = RandomForestRegressor(n_estimators=200, random_state=42)
+    model.fit(X_train, y_train, sample_weight=weights)
+    return model
 
-# 4) Predict
-X_up = up.drop(columns=['Year','Driver','Team'])
-up['PredTime'] = model.predict(X_up)
-up['PredRank'] = up['PredTime'].rank(method='first')
 
-# 5) Show
-print(
-    up
-    .sort_values('PredRank')
-    [['Driver','PredRank','PredTime']]
-    .to_string(index=False)
-)
+def predict_upcoming(model):
+    """Predict upcoming qualifying times using the provided model."""
+    up = pd.read_csv('features_upcoming_with_tyres.csv')
+    X_up = up.drop(columns=['Year', 'Driver', 'Team'])
+    up['PredTime'] = model.predict(X_up)
+    up['PredRank'] = up['PredTime'].rank(method='first')
+    return up[['Driver', 'PredRank', 'PredTime']].sort_values('PredRank')
+
+
+def main():
+    model = train_model()
+    results = predict_upcoming(model)
+    print(results.to_string(index=False))
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ matplotlib
 numpy
 pandas
 scikit-learn
+streamlit


### PR DESCRIPTION
## Summary
- enable Streamlit in requirements
- refactor model into train/predict functions
- add a simple Streamlit app to run predictions

## Testing
- `python -m py_compile model.py app.py`
- `python sanity_check_test.py` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6864a66bc51c8324be5ffc17f214f170