### PR TITLE
Add 2025 fetch script and CLI options

### DIFF
--- a/fetch_2025_all_events.py
+++ b/fetch_2025_all_events.py
@@ -1,0 +1,24 @@
+import pandas as pd
+from pathlib import Path
+import fastf1
+from fastf1_data import fetch_event_sessions
+
+
+def fetch_all_2025_races(sessions=("FP1", "FP2", "FP3", "Q", "R")):
+    """Fetch lap data for every 2025 Grand Prix and save to parquet."""
+    schedule = fastf1.get_event_schedule(2025)
+    out_dir = Path("data/2025")
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    for event in schedule["EventName"]:
+        print(f"\nFetching sessions for {event} 2025")
+        df = fetch_event_sessions(2025, event, sessions=sessions)
+        fname = event.lower().replace(" ", "_")
+        fn = out_dir / f"{fname}_2025.parquet"
+        df.to_parquet(fn)
+        print(f"✔ Saved {len(df)} laps to {fn}")
+
+
+if __name__ == "__main__":
+    fetch_all_2025_races()
+

--- a/model.py
+++ b/model.py
@@ -2,9 +2,9 @@ import pandas as pd
 from sklearn.ensemble import RandomForestRegressor
 
 
-def train_model():
-    """Train a RandomForestRegressor on the tyre-enhanced feature table."""
-    train = pd.read_csv('features_train_with_tyres.csv')
+def train_model(train_path="features_train_with_tyres.csv"):
+    """Train a RandomForestRegressor on the given feature table."""
+    train = pd.read_csv(train_path)
     drop_cols = ['Year', 'Driver', 'Team', 'Best_Q']
     X_train = train.drop(columns=drop_cols)
     y_train = train['Best_Q']
@@ -15,20 +15,38 @@ def train_model():
     return model
 
 
-def predict_upcoming(model):
+def predict_upcoming(model, upcoming_path="features_upcoming_with_tyres.csv"):
     """Predict upcoming qualifying times using the provided model."""
-    up = pd.read_csv('features_upcoming_with_tyres.csv')
+    up = pd.read_csv(upcoming_path)
     X_up = up.drop(columns=['Year', 'Driver', 'Team'])
     up['PredTime'] = model.predict(X_up)
     up['PredRank'] = up['PredTime'].rank(method='first')
     return up[['Driver', 'PredRank', 'PredTime']].sort_values('PredRank')
 
 
-def main():
-    model = train_model()
-    results = predict_upcoming(model)
+def main(train_path="features_train_with_tyres.csv",
+         upcoming_path="features_upcoming_with_tyres.csv"):
+    model = train_model(train_path)
+    results = predict_upcoming(model, upcoming_path)
     print(results.to_string(index=False))
 
 
 if __name__ == "__main__":
-    main()
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Train model and predict upcoming qualifying times"
+    )
+    parser.add_argument(
+        "--train",
+        default="features_train_with_tyres.csv",
+        help="CSV with training features",
+    )
+    parser.add_argument(
+        "--upcoming",
+        default="features_upcoming_with_tyres.csv",
+        help="CSV with upcoming race features",
+    )
+    args = parser.parse_args()
+
+    main(args.train, args.upcoming)

--- a/run_belgium_prediction.py
+++ b/run_belgium_prediction.py
@@ -1,0 +1,12 @@
+from model import train_model, predict_upcoming
+
+
+def main():
+    model = train_model()
+    results = predict_upcoming(model, "features_belgium_2025_with_tyres.csv")
+    print(results.to_string(index=False))
+
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
## Summary
- add script to download session data for every 2025 race
- make `model.py` accept custom training and upcoming datasets via CLI options
- add helper script to run Belgium 2025 prediction

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687da8b9e1e88324a531c571fa6362bd